### PR TITLE
Replace fmt.Sprintf with equivalent strconv.Itoa

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 )
 
 const basePath = "/tmp"
@@ -22,7 +23,7 @@ func loadFile(name string) (*os.File, error) {
 
 func main() {
 	for i := 0; i < 5; i++ {
-		f, err := loadFile(fmt.Sprintf("%d", i))
+		f, err := loadFile(strconv.Itoa(i))
 		if err != nil {
 			fmt.Printf("error: %s\n", err)
 			os.Exit(1)


### PR DESCRIPTION
This batch change replaces `fmt.Sprintf` with `strconv.Itoa`

[_Created by Sourcegraph batch change `elzanne.wentzel/sprintf-to-itoa`._](https://demo.sourcegraph.com/users/elzanne.wentzel/batch-changes/sprintf-to-itoa)